### PR TITLE
Improve util.js regexes

### DIFF
--- a/lib/util.js
+++ b/lib/util.js
@@ -1,3 +1,5 @@
+var TRIM_RIGHT_REGEX = /\s*$/;
+
 module.exports = {
   indexOf: function (arr, item) {
     var i, j;
@@ -30,6 +32,6 @@ module.exports = {
     if (String.prototype.trimRight) {
       return str.trimRight();
     }
-    return str.replace(/\s*$/g, '');
+    return str.replace(TRIM_RIGHT_REGEX, '');
   }
 };

--- a/lib/util.js
+++ b/lib/util.js
@@ -24,12 +24,12 @@ module.exports = {
     if (String.prototype.trim) {
       return str.trim();
     }
-    return str.replace(/(^\s*)|(\s*$)/g, '');
+    return str.replace(/^\s*|\s*$/g, '');
   },
   trimRight: function (str) {
     if (String.prototype.trimRight) {
       return str.trimRight();
     }
-    return str.replace(/(\s*$)/g, '');
+    return str.replace(/\s*$/g, '');
   }
 };

--- a/lib/util.js
+++ b/lib/util.js
@@ -1,4 +1,4 @@
-var TRIM_RIGHT_REGEX = /\s*$/;
+var TRIM_RIGHT_REGEX = /\s+$/;
 
 module.exports = {
   indexOf: function (arr, item) {
@@ -26,7 +26,7 @@ module.exports = {
     if (String.prototype.trim) {
       return str.trim();
     }
-    return str.replace(/^\s*|\s*$/g, '');
+    return str.replace(/^\s+|\s+$/g, '');
   },
   trimRight: function (str) {
     if (String.prototype.trimRight) {


### PR DESCRIPTION
These capture groups aren't used, so we can remove them
to simplify the regexes and improve performance a little. I also
hoisted the trimRight regex to the module level so it isn't created
every time the function is run, and improved the regex perf
by using `+` instead of `*`.