### PR TITLE
fix(default): added row-gap and gap

### DIFF
--- a/lib/default.js
+++ b/lib/default.js
@@ -155,6 +155,7 @@ function getDefaultWhiteList () {
   whiteList['font-variant-numeric'] = true; // default: normal
   whiteList['font-variant-position'] = true; // default: normal
   whiteList['font-weight'] = true; // default: normal
+  whiteList['gap'] = false; // default: normal normal
   whiteList['grid'] = false; // default: depending on individual properties
   whiteList['grid-area'] = false; // default: depending on individual properties
   whiteList['grid-auto-columns'] = false; // default: auto

--- a/lib/default.js
+++ b/lib/default.js
@@ -276,6 +276,7 @@ function getDefaultWhiteList () {
   whiteList['right'] = false; // default: auto
   whiteList['rotation'] = false; // default: 0
   whiteList['rotation-point'] = false; // default: 50% 50%
+  whiteList['row-gap'] = false; // default: normal
   whiteList['ruby-align'] = false; // default: auto
   whiteList['ruby-merge'] = false; // default: separate
   whiteList['ruby-position'] = false; // default: before


### PR DESCRIPTION
The CSS properties [row-gap](https://developer.mozilla.org/en-US/docs/Web/CSS/row-gap) and [gap](https://developer.mozilla.org/en-US/docs/Web/CSS/gap), which is used for multi-column elements and flex and grid containers, seems to be missing. Should it be added?